### PR TITLE
setup: Fallback to /etc/kernelcraft.conf file .config doesn't exists

### DIFF
--- a/kernelcraft/utils.py
+++ b/kernelcraft/utils.py
@@ -1,5 +1,5 @@
 from pathlib import Path
 
 VERSION = '1.8'
-conf_path = Path(Path.home(), '.config', 'kernelcraft')
-conf_file = Path(conf_path, 'kernelcraft.conf')
+CONF_PATH = Path(Path.home(), '.config', 'kernelcraft')
+CONF_FILE = Path(CONF_PATH, 'kernelcraft.conf')

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 import os
 import sys
 from setuptools import setup
-from kernelcraft.utils import VERSION, conf_path
+from kernelcraft.utils import VERSION, CONF_PATH
 
 if sys.version_info < (3,3):
     print('kernelcraft requires Python 3.3 or higher')
@@ -29,7 +29,7 @@ setup(
         ]
     },
     data_files = [
-        (str(conf_path), ['cfg/kernelcraft.conf']),
+        (str(CONF_PATH), ['cfg/kernelcraft.conf']),
     ],
     classifiers=['Environment :: Console',
                  'Intended Audience :: Developers',


### PR DESCRIPTION
The message about missing file still reflect the older /etc/ path, but it shouldn't be a problem for older and new new users. Also, convert configuration paths to uppercase.